### PR TITLE
WIP: Tests for system.diagnostic.eventlog.reader

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogReaderTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogReaderTests.cs
@@ -12,9 +12,11 @@ namespace System.Diagnostics.Tests
     public class EventLogReaderTests
     {
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
-        public void CreateReader()
+        public void ApplicationEventLog_Record()
         {
-            // var eventLog = new EventLogReader("XXX");
+            var eventLog = new EventLogReader("Application");
+            var record = eventLog.ReadEvent();
+            Assert.NotNull(record);
         }
 
   

--- a/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogReaderTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogReaderTests.cs
@@ -17,9 +17,18 @@ namespace System.Diagnostics.Tests
             var eventLog = new EventLogReader("Application");
             var record = eventLog.ReadEvent();
             Assert.NotNull(record);
+            Assert.Equal(record.LogName, "Application");
         }
 
-  
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        public void ApplicationEventLogQuery_Record()
+        {
+            var query = new EventLogQuery("Application", PathType.LogName) { ReverseDirection = true };
+            var eventLog = new EventLogReader(query);
+            var record = eventLog.ReadEvent();
+            Assert.NotNull(record);
+            Assert.Equal(record.LogName, "Application");
+        }
     }
 }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogReaderTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogReaderTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
-using System.IO;
-using Xunit;
 using System.Diagnostics.Eventing.Reader;
+using Xunit;
 
 namespace System.Diagnostics.Tests
 {
@@ -14,20 +12,47 @@ namespace System.Diagnostics.Tests
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
         public void ApplicationEventLog_Record()
         {
-            var eventLog = new EventLogReader("Application");
-            var record = eventLog.ReadEvent();
-            Assert.NotNull(record);
-            Assert.Equal(record.LogName, "Application");
+            using (var eventLog = new EventLogReader("Application"))
+            {
+                var record = eventLog.ReadEvent();
+                Assert.NotNull(record);
+                Assert.Equal("Application", record.LogName);
+            }
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
         public void ApplicationEventLogQuery_Record()
         {
             var query = new EventLogQuery("Application", PathType.LogName) { ReverseDirection = true };
-            var eventLog = new EventLogReader(query);
-            var record = eventLog.ReadEvent();
-            Assert.NotNull(record);
-            Assert.Equal(record.LogName, "Application");
+            using (var eventLog = new EventLogReader(query))
+            {
+                var record = eventLog.ReadEvent();
+                Assert.NotNull(record);
+                Assert.Equal("Application", record.LogName);
+            }
+        }
+
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        public void NestedEventLog_Record()
+        {
+            using (var eventLog = new EventLogReader("Microsoft-Windows-PowerShell/Operational"))
+            {
+                var record = eventLog.ReadEvent();
+                Assert.NotNull(record);
+                Assert.Equal("Microsoft-Windows-PowerShell/Operational", record.LogName);
+            }
+        }
+
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        public void NestedEventLogQuery_Record()
+        {
+            var query = new EventLogQuery("Microsoft-Windows-PowerShell/Operational", PathType.LogName) { ReverseDirection = true };
+            using (var eventLog = new EventLogReader(query))
+            {
+                var record = eventLog.ReadEvent();
+                Assert.NotNull(record);
+                Assert.Equal("Microsoft-Windows-PowerShell/Operational", record.LogName);
+            }
         }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogWatcherTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogReaderTests/EventLogWatcherTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Eventing.Reader;
+using System.Threading;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public class EventLogWatcherTests
+    {
+        static AutoResetEvent signal;
+        private const string message = "EventRecordWrittenTestMessage";
+        private int eventCounter;
+
+        public void RaisingEvent(string log, string methodName, bool waitOnEvent = true)
+        {
+            signal = new AutoResetEvent(false);
+            eventCounter = 0;
+            string source = "Source_" + methodName;
+
+            try
+            {
+                EventLog.CreateEventSource(source, log);
+                var query = new EventLogQuery(log, PathType.LogName);
+                using (EventLog eventLog = new EventLog())
+                using (EventLogWatcher eventLogWatcher = new EventLogWatcher(query))
+                {
+                    eventLog.Source = source;
+                    eventLogWatcher.EventRecordWritten += (s, e) =>
+                    {
+                        eventCounter += 1;
+                        signal.Set();
+                    };
+                    Helpers.RetryOnWin7(() => eventLogWatcher.Enabled = waitOnEvent);
+                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
+                    if (waitOnEvent)
+                    {
+                        Assert.True(signal.WaitOne(6000));
+                    }
+                }
+            }
+            finally
+            {
+                EventLog.DeleteEventSource(source);
+                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+            }
+        }
+
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
+        public void RecordWrittenEventRaised()
+        {
+            RaisingEvent("EnableEvent", nameof(RecordWrittenEventRaised));
+            Assert.NotEqual(0, eventCounter);
+        }
+
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
+        public void RecordWrittenEventRaiseDisable()
+        {
+            RaisingEvent("DisableEvent", nameof(RecordWrittenEventRaiseDisable), waitOnEvent: false);
+            Assert.Equal(0, eventCounter);
+        }
+    }
+}

--- a/src/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
+++ b/src/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
@@ -7,6 +7,7 @@
     <Compile Include="EventInstanceTests.cs" />
     <Compile Include="EventLogEntryCollectionTests.cs" />
     <Compile Include="EventLogReaderTests\EventLogReaderTests.cs" />
+    <Compile Include="EventLogReaderTests\EventLogWatcherTests.cs" />
     <Compile Include="EventLogTests\EventLogEntryWrittenTest.cs" />
     <Compile Include="EventLogTests\EventLogSourceCreationTests.cs" />
     <Compile Include="EventLogTests\EventLogTests.cs" />


### PR DESCRIPTION
I started adding a couple of tests for `EventLogReader` and `EventLogWatcher` - please review and let me know what other tests I should add.

These tests are discovered and pass on my Win 10 box when running:
```
%HOME%\oss\corefx\src\System.Diagnostics.EventLog\tests>msbuild /t:RebuildAndTest
```

Things I'm not sure:
* How to write an `EventLogWatcher` test for "nested" logs - can I use an existing log like "Microsoft-Windows-PowerShell/Operational" and write to it?
* How to filter the `EventLogWatcher` to just query for logs with the specified source - the current filter might not be specific enough